### PR TITLE
Adding options for EBS encryption

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -115,7 +115,7 @@ resource "aws_instance" "this" {
   instance_type     = var.fw_instance_type
   availability_zone = "${data.aws_region.current.name}${var.az_suffix}"
   key_name          = var.key_name
-  
+
   # Apply bootstrap.sh
   user_data = templatefile("${path.module}/bootstrap.sh",
     {
@@ -123,11 +123,17 @@ resource "aws_instance" "this" {
       "mgmt_net"    = var.mgmt_net
     }
   )
+  root_block_device {
+    encrypted = var.fw_volume_encrypt
+    kms_key_id = var.fw_volume_encrypt_kms_key_id
+  }
 
   ebs_block_device {
     device_name = "/dev/sdb"
     volume_size = "30"
     volume_type = "standard"
+    encrypted = var.fw_volume_encrypt
+    kms_key_id = var.fw_volume_encrypt_kms_key_id
   }
 
   network_interface {

--- a/variables.tf
+++ b/variables.tf
@@ -53,3 +53,15 @@ variable "fw_instance_type" {
   description = "AWS instance type"
   default     = "t2.micro"
 }
+
+variable "fw_volume_encrypt" {
+  type = bool
+  description = "Enable Firewall EBS Encryption"
+  default = false
+}
+
+variable "fw_volume_encrypt_kms_key_id" {
+  type = string
+  description = "KMS Key to use for EBS encryption"
+  default = null
+}


### PR DESCRIPTION
Adding option for EBS encryption and KMS key id when aws_ebs_encryption_by_default is not enabled by default in environment.